### PR TITLE
[2024/07/24] feature/user/social-login >> 카카오톡 소셜 로그인 구현

### DIFF
--- a/src/main/java/com/befriend/detour/domain/user/controller/UserController.java
+++ b/src/main/java/com/befriend/detour/domain/user/controller/UserController.java
@@ -1,17 +1,19 @@
 package com.befriend.detour.domain.user.controller;
 
 import com.befriend.detour.domain.user.dto.SignupRequestDto;
+import com.befriend.detour.domain.user.service.KakaoService;
 import com.befriend.detour.domain.user.service.UserService;
 import com.befriend.detour.global.dto.CommonResponseDto;
 import com.befriend.detour.global.security.UserDetailsImpl;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequiredArgsConstructor
@@ -19,12 +21,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class UserController {
 
     private final UserService userService;
+    private final KakaoService kakaoService;
 
     @PostMapping("/signup")
     public ResponseEntity<CommonResponseDto> signup(@Valid @RequestBody SignupRequestDto signupRequestDto) {
         userService.signup(signupRequestDto);
 
-        return ResponseEntity.ok(new CommonResponseDto(201, "회원가입에 성공하였습니다. 🌠", null));
+        return new ResponseEntity<>(new CommonResponseDto(201, "회원가입에 성공하였습니다. 🌠", null), HttpStatus.CREATED);
     }
 
     @PostMapping("/logout")
@@ -32,6 +35,13 @@ public class UserController {
         userService.logout(userDetails.getUser());
 
         return ResponseEntity.ok(new CommonResponseDto(200, "로그아웃에 성공하였습니다. 🎉", null));
+    }
+
+    @GetMapping("/login/oauth2/code/kakao")
+    public ResponseEntity<CommonResponseDto> kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
+        kakaoService.kakaoLogin(code, response);
+
+        return ResponseEntity.ok(new CommonResponseDto(200, "카카오톡 로그인에 성공하였습니다. 🌠", null));
     }
 
 }

--- a/src/main/java/com/befriend/detour/domain/user/dto/KaKaoUserInfoDto.java
+++ b/src/main/java/com/befriend/detour/domain/user/dto/KaKaoUserInfoDto.java
@@ -1,0 +1,20 @@
+package com.befriend.detour.domain.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KaKaoUserInfoDto {
+
+    private Long id;
+    private String nickname;
+    private String email;
+
+    public KaKaoUserInfoDto(Long id, String nickname, String email) {
+        this.id = id;
+        this.nickname = nickname;
+        this.email = email;
+    }
+
+}

--- a/src/main/java/com/befriend/detour/domain/user/entity/User.java
+++ b/src/main/java/com/befriend/detour/domain/user/entity/User.java
@@ -72,4 +72,5 @@ public class User extends TimeStamped {
 
         return this;
     }
+
 }

--- a/src/main/java/com/befriend/detour/domain/user/entity/User.java
+++ b/src/main/java/com/befriend/detour/domain/user/entity/User.java
@@ -19,11 +19,11 @@ public class User extends TimeStamped {
     @Column(nullable = false)
     private String email;
 
-    @Column(nullable = false)
+    @Column
     private String loginId;
 
     @Column
-    private String kakaoId;
+    private Long kakaoId;
 
     @Column(nullable = false)
     private String password;
@@ -50,6 +50,15 @@ public class User extends TimeStamped {
         this.role = userRole;
     }
 
+    public User(String email, String encodedPassword, String nickname, UserStatusEnum userStatusEnum, UserRoleEnum userRoleEnum, Long kakaoId) {
+        this.password = encodedPassword;
+        this.nickname = nickname;
+        this.email = email;
+        this.status = userStatusEnum;
+        this.role = userRoleEnum;
+        this.kakaoId = kakaoId;
+    }
+
     public void encryptionPassword(String password) {
         this.password = password;
     }
@@ -58,4 +67,9 @@ public class User extends TimeStamped {
         this.refreshToken = refresh;
     }
 
+    public User kakaoIdUpdate(Long kakaoId) {
+        this.kakaoId = kakaoId;
+
+        return this;
+    }
 }

--- a/src/main/java/com/befriend/detour/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/befriend/detour/domain/user/repository/UserRepository.java
@@ -6,5 +6,4 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
-
 }

--- a/src/main/java/com/befriend/detour/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/befriend/detour/domain/user/repository/UserRepositoryCustom.java
@@ -7,9 +7,13 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepositoryCustom {
+
     Optional<User> findByNickname(String nickname);
 
     Optional<User> findByLoginId(String loginId);
 
     Optional<User> findByEmail(String Email);
+
+    Optional<User> findByKakaoId(Long kakaoId);
+
 }

--- a/src/main/java/com/befriend/detour/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/befriend/detour/domain/user/repository/UserRepositoryImpl.java
@@ -45,4 +45,14 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         return Optional.ofNullable(result);
     }
 
+    @Override
+    public Optional<User> findByKakaoId(Long kakaoId) {
+
+        User result = jpaQueryFactory.selectFrom(user)
+                .where(user.kakaoId.eq(kakaoId))
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
 }

--- a/src/main/java/com/befriend/detour/domain/user/service/KakaoService.java
+++ b/src/main/java/com/befriend/detour/domain/user/service/KakaoService.java
@@ -1,0 +1,91 @@
+package com.befriend.detour.domain.user.service;
+
+import com.befriend.detour.domain.user.dto.KaKaoUserInfoDto;
+import com.befriend.detour.domain.user.repository.UserRepository;
+import com.befriend.detour.global.jwt.JwtProvider;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.http.HttpHeaders;
+
+import java.net.URI;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+    private final RestTemplate restTemplate;
+    private final JwtProvider jwtProvider;
+
+    @Value("${SOCIAL_KAKAO_CLIENT_ID}")
+    private String kakaoClientId;
+
+    @Value("${SOCIAL_KAKAO_REDIRECT_URI}")
+    private String kakaoRedirectUri;
+
+    public String kakaoLogin(String code) throws JsonProcessingException {
+        // 1. "인가 코드"로 "엑세스 토큰" 요청
+        String accessToken = getToken(code);
+
+        // 2. 토큰으로 카카오 API 호출 : "엑세스 토큰"으로 "카카오 사용자 정보"가져오기
+        KaKaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(accessToken);
+
+        return null;
+    }
+
+    private KaKaoUserInfoDto getKakaoUserInfo(String accessToken) {
+        return null;
+    }
+
+    private String getToken(String code) throws JsonProcessingException {
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com")
+                .path("/oauth/token")
+                .encode()
+                .build()
+                .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code"); // 인증 타입 설정
+        body.add("client_id", kakaoClientId);
+        body.add("redirect_uri", kakaoRedirectUri);
+        body.add("code", code);
+
+        RequestEntity<MultiValueMap<String,String>> requestEntity = RequestEntity
+                .post(uri) // POST 메서드로 요청
+                .headers(headers) // 헤더 설정
+                .body(body); // 바디 설정
+
+        // HTTP 요청 보내기
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity, // 요청 엔티티
+                String.class // 응답 타입
+        );
+
+        // HTTP 응답 (JSON) -> 액세스 토큰 파싱
+        // 응답 본문을 JSON 노드로 파싱
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+
+        // 액세스 토큰 추출 및 반환
+        return jsonNode.get("access_token").asText();
+    }
+
+}

--- a/src/main/java/com/befriend/detour/domain/user/service/KakaoService.java
+++ b/src/main/java/com/befriend/detour/domain/user/service/KakaoService.java
@@ -1,13 +1,18 @@
 package com.befriend.detour.domain.user.service;
 
 import com.befriend.detour.domain.user.dto.KaKaoUserInfoDto;
+import com.befriend.detour.domain.user.entity.User;
+import com.befriend.detour.domain.user.entity.UserRoleEnum;
+import com.befriend.detour.domain.user.entity.UserStatusEnum;
 import com.befriend.detour.domain.user.repository.UserRepository;
 import com.befriend.detour.global.jwt.JwtProvider;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,9 +21,9 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-import org.springframework.http.HttpHeaders;
 
 import java.net.URI;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -35,14 +40,25 @@ public class KakaoService {
     @Value("${SOCIAL_KAKAO_REDIRECT_URI}")
     private String kakaoRedirectUri;
 
-    public String kakaoLogin(String code) throws JsonProcessingException {
+    public void kakaoLogin(String code, HttpServletResponse response) throws JsonProcessingException {
         // 1. "인가 코드"로 "엑세스 토큰" 요청
         String accessToken = getToken(code);
 
         // 2. 토큰으로 카카오 API 호출 : "엑세스 토큰"으로 "카카오 사용자 정보"가져오기
         KaKaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(accessToken);
 
-        return null;
+        // 3. 필요 시에 회원가입
+        User kakaoUser = registerKakaoUserIfNeeded(kakaoUserInfo);
+
+        // 4. JWT 반환
+        String jwtAccessToken = jwtProvider.createAccessToken(kakaoUser.getNickname(), kakaoUser.getRole());
+        String jwtRefreshToken = jwtProvider.createRefreshToken(kakaoUser.getNickname());
+
+        kakaoUser.updateRefresh(jwtRefreshToken);
+        userRepository.save(kakaoUser);
+
+        response.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + jwtAccessToken);
+        response.setStatus(HttpServletResponse.SC_OK);
     }
 
     private String getToken(String code) throws JsonProcessingException {
@@ -88,7 +104,7 @@ public class KakaoService {
         // 요청 URL 만들기
         URI uri = UriComponentsBuilder
                 .fromUriString("https://kapi.kakao.com") // 카카오 API 서버 URI
-                .path("/users/info") // 사용자 정보 요청 경로
+                .path("/v2/user/me") // 사용자 정보 요청 경로
                 .encode()
                 .build()
                 .toUri();
@@ -119,7 +135,32 @@ public class KakaoService {
         return new KaKaoUserInfoDto(id, nickname, email);
     }
 
+    // 3. 필요 시에 회원가입
+    private User registerKakaoUserIfNeeded(KaKaoUserInfoDto kakaoUserInfo) {
+        // DB 에 중복된 Kakao Id 가 있는지 확인
+        Long kakaoId = kakaoUserInfo.getId();
+        User kakaoUser = userRepository.findByKakaoId(kakaoId).orElse(null);
 
+        if (kakaoUser == null) {  //DB에 해당 카카오 아이디 없다면 회원가입 진행
+            // 카카오 사용자 email 동일한 email 가진 회원이 있는지 확인
+            String kakaoEmail = kakaoUserInfo.getEmail();
+            User sameEmailUser = userRepository.findByEmail(kakaoEmail).orElse(null);
+            if (sameEmailUser != null) {  //DB에 이미 존재하는 이메일을 가진 회원이 있다면
+                kakaoUser = sameEmailUser;  //같은 회원이라고 덮어씌우기
+                kakaoUser = kakaoUser.kakaoIdUpdate(kakaoId);  //기존 회원정보에 카카오 Id 추가
+            } else {  // 신규 회원가입
+                // password: random UUID
+                String password = UUID.randomUUID().toString();  //password는 UUID를 사용해서 랜덤으로 생성
+                String encodedPassword = passwordEncoder.encode(password);  //암호화
 
+                // email: kakao email
+                String email = kakaoUserInfo.getEmail();
+
+                kakaoUser = new User(email, encodedPassword, kakaoUserInfo.getNickname(), UserStatusEnum.ACTIVE, UserRoleEnum.USER, kakaoId);
+            }
+        }
+
+        return kakaoUser;
+    }
 
 }

--- a/src/main/java/com/befriend/detour/domain/user/service/KakaoService.java
+++ b/src/main/java/com/befriend/detour/domain/user/service/KakaoService.java
@@ -45,10 +45,6 @@ public class KakaoService {
         return null;
     }
 
-    private KaKaoUserInfoDto getKakaoUserInfo(String accessToken) {
-        return null;
-    }
-
     private String getToken(String code) throws JsonProcessingException {
         // 요청 URL 만들기
         URI uri = UriComponentsBuilder
@@ -69,7 +65,7 @@ public class KakaoService {
         body.add("redirect_uri", kakaoRedirectUri);
         body.add("code", code);
 
-        RequestEntity<MultiValueMap<String,String>> requestEntity = RequestEntity
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
                 .post(uri) // POST 메서드로 요청
                 .headers(headers) // 헤더 설정
                 .body(body); // 바디 설정
@@ -87,5 +83,43 @@ public class KakaoService {
         // 액세스 토큰 추출 및 반환
         return jsonNode.get("access_token").asText();
     }
+
+    private KaKaoUserInfoDto getKakaoUserInfo(String accessToken) throws JsonProcessingException {
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kapi.kakao.com") // 카카오 API 서버 URI
+                .path("/users/info") // 사용자 정보 요청 경로
+                .encode()
+                .build()
+                .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(new LinkedMultiValueMap<>());
+
+        // HTTP 요청 보내기
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity,
+                String.class
+        );
+
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        Long id = jsonNode.get("id").asLong();
+        String nickname = jsonNode.get("properties")
+                .get("nickname").asText();
+        String email = jsonNode.get("kakao_account")
+                .get("email").asText();
+
+        return new KaKaoUserInfoDto(id, nickname, email);
+    }
+
+
+
 
 }

--- a/src/main/java/com/befriend/detour/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/befriend/detour/global/config/RestTemplateConfig.java
@@ -1,0 +1,23 @@
+package com.befriend.detour.global.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                // RestTemplate 로 외부 api 호출 시 일정 시간이 지나도 응답이 없을 때
+                // 무한 대기 상태 방지를 위해 강제 종료 설정
+                .setConnectTimeout(Duration.ofSeconds(5)) // 5초로 설정
+                .setReadTimeout(Duration.ofSeconds(5)) // 5초
+                .build();
+    }
+
+}

--- a/src/main/java/com/befriend/detour/global/config/SecurityConfig.java
+++ b/src/main/java/com/befriend/detour/global/config/SecurityConfig.java
@@ -65,6 +65,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/users/signup").permitAll()
                         .requestMatchers("/api/users/login").permitAll()
                         .requestMatchers("/api/admin/**").hasAuthority("ADMIN")
+                        .requestMatchers("/api/users/login/oauth2/code/kakao").permitAll()
                         .anyRequest().authenticated()
         );
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,7 @@ spring:
             authorization-grant-type: authorization_code
             scope:
               - account_email
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            redirect-uri: http://localhost:8081/api/users/login/oauth2/code/kakao
             client-name: Kakao
             provider: kakao
         provider:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#6 
close #6 

## 📝 작업 내용
- 카카오톡 소셜 로그인 기능 구현
- 카카오톡 소셜 로그인 api 생성
- 동일한 이메일 사용자가 있을 시 아이디 병합 로직 구현
- 동일한 이메일 사용자가 없을 시 새로운 회원가입 진행 로직 구현
- 카카오톡 api 허가하도록 변경
- User 필드 변경 kakaoId  String -> Long, loginId nullable로 변경

### 📸 스크린샷
카카오 로그인하여 회원가입 된 모습
![image](https://github.com/user-attachments/assets/2f0d2e02-597e-425b-a277-659fbc5d98d3)
