### PR TITLE
[2024/07/24] feature/dailyplan/cr >> DailyPlan 조회 기능 구현

### DIFF
--- a/http/5. 데일리플랜.http
+++ b/http/5. 데일리플랜.http
@@ -11,3 +11,8 @@ Authorization: {{access_token}}
 GET http://localhost:8081/api/schedules/1/daily-plans
 Content-Type: application/json
 Authorization: {{access_token}}
+
+### 5-3. DailyPlan 단건 조회
+GET http://localhost:8081/api/daily-plans/1
+Content-Type: application/json
+Authorization: {{access_token}}

--- a/http/5. 데일리플랜.http
+++ b/http/5. 데일리플랜.http
@@ -1,8 +1,13 @@
 ### 5-1. 데일리플랜 생성
-POST http://localhost:8081/api/schedules/1/dailyPlans
+POST http://localhost:8081/api/schedules/1/daily-plans
 Content-Type: application/json
 Authorization: {{access_token}}
 
 {
-  "day": 2
+  "day": 1
 }
+
+### 5-2. 해당 Schedule에 대한 DailyPlan 목록 조회
+GET http://localhost:8081/api/schedules/1/daily-plans
+Content-Type: application/json
+Authorization: {{access_token}}

--- a/src/main/java/com/befriend/detour/domain/dailyplan/controller/DailyPlanController.java
+++ b/src/main/java/com/befriend/detour/domain/dailyplan/controller/DailyPlanController.java
@@ -1,12 +1,15 @@
 package com.befriend.detour.domain.dailyplan.controller;
 
 import com.befriend.detour.domain.dailyplan.dto.DailyPlanRequestDto;
+import com.befriend.detour.domain.dailyplan.dto.DailyPlanResponseDto;
 import com.befriend.detour.domain.dailyplan.service.DailyPlanService;
 import com.befriend.detour.global.dto.CommonResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +24,13 @@ public class DailyPlanController {
         dailyPlanService.createDailyPlan(scheduleId, dailyPlanRequestDto);
 
         return new ResponseEntity<>(new CommonResponseDto<>(201, "데일리 플랜 생성에 성공하였습니다. 🎉", null), HttpStatus.CREATED);
+    }
+
+    @GetMapping("/schedules/{scheduleId}/daily-plans")
+    public ResponseEntity<CommonResponseDto<List<DailyPlanResponseDto>>> getDailyPlansByScheduleId(@PathVariable(name = "scheduleId") Long scheduleId) {
+        List<DailyPlanResponseDto> responseDtoList = dailyPlanService.getDailyPlansByScheduleId(scheduleId);
+
+        return ResponseEntity.ok(new CommonResponseDto<>(200, "해당 일정에 대한 데일리 플랜 목록 조회에 성공하였습니다. 🎉", responseDtoList));
     }
 
 }

--- a/src/main/java/com/befriend/detour/domain/dailyplan/controller/DailyPlanController.java
+++ b/src/main/java/com/befriend/detour/domain/dailyplan/controller/DailyPlanController.java
@@ -33,4 +33,11 @@ public class DailyPlanController {
         return ResponseEntity.ok(new CommonResponseDto<>(200, "해당 일정에 대한 데일리 플랜 목록 조회에 성공하였습니다. 🎉", responseDtoList));
     }
 
+    @GetMapping("/daily-plans/{dailyPlanId}")
+    public ResponseEntity<CommonResponseDto<DailyPlanResponseDto>> getDailyPlan(@PathVariable(name = "dailyPlanId") Long dailyPlanId) {
+        DailyPlanResponseDto responseDto = dailyPlanService.getDailyPlan(dailyPlanId);
+
+        return ResponseEntity.ok(new CommonResponseDto<>(200, "데일리 플랜 단건 조회에 성공하였습니다. 🎉", responseDto));
+    }
+
 }

--- a/src/main/java/com/befriend/detour/domain/dailyplan/dto/DailyPlanResponseDto.java
+++ b/src/main/java/com/befriend/detour/domain/dailyplan/dto/DailyPlanResponseDto.java
@@ -1,0 +1,17 @@
+package com.befriend.detour.domain.dailyplan.dto;
+
+import com.befriend.detour.domain.dailyplan.entity.DailyPlan;
+import lombok.Getter;
+
+@Getter
+public class DailyPlanResponseDto {
+
+    private Long scheduleId;
+    private Long day;
+
+    public DailyPlanResponseDto(DailyPlan dailyPlan) {
+        this.scheduleId = dailyPlan.getSchedule().getId();
+        this.day = dailyPlan.getDay();
+    }
+
+}

--- a/src/main/java/com/befriend/detour/domain/dailyplan/repository/DailyPlanRepository.java
+++ b/src/main/java/com/befriend/detour/domain/dailyplan/repository/DailyPlanRepository.java
@@ -1,9 +1,13 @@
 package com.befriend.detour.domain.dailyplan.repository;
 
 import com.befriend.detour.domain.dailyplan.entity.DailyPlan;
+import com.befriend.detour.domain.schedule.entity.Schedule;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface DailyPlanRepository extends JpaRepository<DailyPlan, Long> {
+    List<DailyPlan> findAllByScheduleOrderByDay(Schedule checkSchedule);
 }

--- a/src/main/java/com/befriend/detour/domain/dailyplan/service/DailyPlanService.java
+++ b/src/main/java/com/befriend/detour/domain/dailyplan/service/DailyPlanService.java
@@ -1,6 +1,7 @@
 package com.befriend.detour.domain.dailyplan.service;
 
 import com.befriend.detour.domain.dailyplan.dto.DailyPlanRequestDto;
+import com.befriend.detour.domain.dailyplan.dto.DailyPlanResponseDto;
 import com.befriend.detour.domain.dailyplan.entity.DailyPlan;
 import com.befriend.detour.domain.dailyplan.repository.DailyPlanRepository;
 import com.befriend.detour.domain.schedule.entity.Schedule;
@@ -9,6 +10,10 @@ import com.befriend.detour.global.exception.CustomException;
 import com.befriend.detour.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,12 +22,28 @@ public class DailyPlanService {
     private final DailyPlanRepository dailyPlanRepository;
     private final ScheduleService scheduleService;
 
+    @Transactional
     public void createDailyPlan(Long scheduleId, DailyPlanRequestDto dailyPlanRequestDto) {
 
         Schedule checkSchedule = scheduleService.findById(scheduleId);
 
         DailyPlan dailyPlan = new DailyPlan(checkSchedule, dailyPlanRequestDto);
         dailyPlanRepository.save(dailyPlan);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DailyPlanResponseDto> getDailyPlansByScheduleId(Long scheduleId) {
+
+        Schedule checkSchedule = scheduleService.findById(scheduleId);
+        List<DailyPlan> dailyPlanList = dailyPlanRepository.findAllByScheduleOrderByDay(checkSchedule);
+
+        List<DailyPlanResponseDto> responseDtoList = new ArrayList<>();
+        for (DailyPlan dailyPlan : dailyPlanList) {
+            DailyPlanResponseDto responseDto = new DailyPlanResponseDto(dailyPlan);
+            responseDtoList.add(responseDto);
+        }
+
+        return responseDtoList;
     }
 
     // dailyPlanId로 데일리플랜 찾기

--- a/src/main/java/com/befriend/detour/domain/dailyplan/service/DailyPlanService.java
+++ b/src/main/java/com/befriend/detour/domain/dailyplan/service/DailyPlanService.java
@@ -46,6 +46,13 @@ public class DailyPlanService {
         return responseDtoList;
     }
 
+    @Transactional(readOnly = true)
+    public DailyPlanResponseDto getDailyPlan(Long dailyPlanId) {
+        DailyPlan checkDailyPlan = findDailyPlanById(dailyPlanId);
+
+        return new DailyPlanResponseDto(checkDailyPlan);
+    }
+
     // dailyPlanId로 데일리플랜 찾기
     public DailyPlan findDailyPlanById(Long dailyPlanId) {
         return dailyPlanRepository.findById(dailyPlanId).orElseThrow(() ->


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #22
> close #22

## 📝 작업 내용

- 해당 scheduleId를 가지는 DailyPlan 목록 조회 기능
- DailyPlan 단건 조회 기능
- 관련 http 파일 코드 작성

### 📸 스크린샷
> ![image](https://github.com/user-attachments/assets/4b8f0e9c-3ea4-4ce7-a904-343013ea910d)
> 
> ![image](https://github.com/user-attachments/assets/77a79b28-82bc-45aa-8b45-c6aa2ab2d3c7)

## 💬 리뷰 요구사항

> 현재 경우에는 조회 시 쿼리DSL로 리팩토링할 필요성을 느끼지 못해 하지 않았는데 혹시 필요하다고 생각하신다면 의견 남겨주시면 감사하겠습니다 :)
