### PR TITLE
[2024/07/24] feature/user/get-edit-profile >> 유저 조회, 프로필 수정 기능 구현

### DIFF
--- a/http/7. 프로필 조회, 수정.http
+++ b/http/7. 프로필 조회, 수정.http
@@ -9,5 +9,25 @@ Content-Type: application/json
 Authorization: {{access_token}}
 
 {
-  "nickname" : "변경"
+  "nickname" : "창브로"
+}
+
+#### 7-3. 이메일 수정
+PATCH http://localhost:8081/api/users/profiles/email
+Content-Type: application/json
+Authorization: {{access_token}}
+
+{
+  "email" : "shlee509@nate.com"
+}
+
+#### 7-4. 비밀번호 수정
+PATCH http://localhost:8081/api/users/profiles/password
+Content-Type: application/json
+Authorization: {{access_token}}
+
+{
+  "password": "Password1!",
+  "newPassword": "Password2!",
+  "confirmNewPassword": "Password3!"
 }

--- a/http/7. 프로필 조회, 수정.http
+++ b/http/7. 프로필 조회, 수정.http
@@ -2,3 +2,12 @@
 GET http://localhost:8081/api/users/profile
 Content-Type: application/json
 Authorization: {{access_token}}
+
+#### 7-2. 닉네임 수정
+PATCH http://localhost:8081/api/users/profiles/nickname
+Content-Type: application/json
+Authorization: {{access_token}}
+
+{
+  "nickname" : "변경"
+}

--- a/http/7. 프로필 조회, 수정.http
+++ b/http/7. 프로필 조회, 수정.http
@@ -1,0 +1,4 @@
+### 7-1. 프로필 조회
+GET http://localhost:8081/api/users/profile
+Content-Type: application/json
+Authorization: {{access_token}}

--- a/src/main/java/com/befriend/detour/domain/user/controller/UserController.java
+++ b/src/main/java/com/befriend/detour/domain/user/controller/UserController.java
@@ -1,8 +1,6 @@
 package com.befriend.detour.domain.user.controller;
 
-import com.befriend.detour.domain.user.dto.EditNicknameRequestDto;
-import com.befriend.detour.domain.user.dto.ProfileResponseDto;
-import com.befriend.detour.domain.user.dto.SignupRequestDto;
+import com.befriend.detour.domain.user.dto.*;
 import com.befriend.detour.domain.user.service.KakaoService;
 import com.befriend.detour.domain.user.service.UserService;
 import com.befriend.detour.global.dto.CommonResponseDto;

--- a/src/main/java/com/befriend/detour/domain/user/controller/UserController.java
+++ b/src/main/java/com/befriend/detour/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.befriend.detour.domain.user.controller;
 
+import com.befriend.detour.domain.user.dto.ProfileResponseDto;
 import com.befriend.detour.domain.user.dto.SignupRequestDto;
 import com.befriend.detour.domain.user.service.KakaoService;
 import com.befriend.detour.domain.user.service.UserService;
@@ -42,6 +43,13 @@ public class UserController {
         kakaoService.kakaoLogin(code, response);
 
         return ResponseEntity.ok(new CommonResponseDto(200, "카카오톡 로그인에 성공하였습니다. 🌠", null));
+    }
+
+    @GetMapping("/profile")
+    public ResponseEntity<CommonResponseDto> getProfile(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        ProfileResponseDto profileResponseDto = userService.getProfile(userDetails.getUser());
+
+        return ResponseEntity.ok(new CommonResponseDto(200, "프로필 조회에 성공하였습니다. 🎉", profileResponseDto));
     }
 
 }

--- a/src/main/java/com/befriend/detour/domain/user/controller/UserController.java
+++ b/src/main/java/com/befriend/detour/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.befriend.detour.domain.user.controller;
 
+import com.befriend.detour.domain.user.dto.EditNicknameRequestDto;
 import com.befriend.detour.domain.user.dto.ProfileResponseDto;
 import com.befriend.detour.domain.user.dto.SignupRequestDto;
 import com.befriend.detour.domain.user.service.KakaoService;
@@ -50,6 +51,13 @@ public class UserController {
         ProfileResponseDto profileResponseDto = userService.getProfile(userDetails.getUser());
 
         return ResponseEntity.ok(new CommonResponseDto(200, "프로필 조회에 성공하였습니다. 🎉", profileResponseDto));
+    }
+
+    @PatchMapping("/profiles/nickname")
+    public ResponseEntity<CommonResponseDto> updateNickname(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody EditNicknameRequestDto editNicknameRequestDto) {
+        ProfileResponseDto profileResponseDto = userService.updateNickname(userDetails.getUser(), editNicknameRequestDto.getNickname());
+
+        return ResponseEntity.ok(new CommonResponseDto(200, "닉네임 수정에 성공하였습니다. 🎉", profileResponseDto));
     }
 
 }

--- a/src/main/java/com/befriend/detour/domain/user/controller/UserController.java
+++ b/src/main/java/com/befriend/detour/domain/user/controller/UserController.java
@@ -60,4 +60,18 @@ public class UserController {
         return ResponseEntity.ok(new CommonResponseDto(200, "닉네임 수정에 성공하였습니다. 🎉", profileResponseDto));
     }
 
+    @PatchMapping("/profiles/email")
+    public ResponseEntity<CommonResponseDto> updateEmail(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody EditEmailRequestDto editEmailRequestDto) {
+        ProfileResponseDto profileResponseDto = userService.updateEmail(userDetails.getUser(), editEmailRequestDto.getEmail());
+
+        return ResponseEntity.ok(new CommonResponseDto(200, "이메일 수정에 성공하였습니다. 🎉", profileResponseDto));
+    }
+
+    @PatchMapping("/profiles/password")
+    public ResponseEntity<CommonResponseDto> updatePassword(@AuthenticationPrincipal UserDetailsImpl userDetails, @RequestBody EditPasswordDto editPasswordDto) {
+        userService.updatePassword(userDetails.getUser(), editPasswordDto);
+
+        return ResponseEntity.ok(new CommonResponseDto(200, "비밀번호 수정에 성공하였습니다. 🎉", null));
+    }
+
 }

--- a/src/main/java/com/befriend/detour/domain/user/dto/EditEmailRequestDto.java
+++ b/src/main/java/com/befriend/detour/domain/user/dto/EditEmailRequestDto.java
@@ -1,0 +1,10 @@
+package com.befriend.detour.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class EditEmailRequestDto {
+
+    private String email;
+
+}

--- a/src/main/java/com/befriend/detour/domain/user/dto/EditNicknameRequestDto.java
+++ b/src/main/java/com/befriend/detour/domain/user/dto/EditNicknameRequestDto.java
@@ -1,0 +1,16 @@
+package com.befriend.detour.domain.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EditNicknameRequestDto {
+
+    private String nickname;
+
+    public EditNicknameRequestDto(String nickname) {
+        this.nickname = nickname;
+    }
+
+}

--- a/src/main/java/com/befriend/detour/domain/user/dto/EditNicknameRequestDto.java
+++ b/src/main/java/com/befriend/detour/domain/user/dto/EditNicknameRequestDto.java
@@ -1,16 +1,10 @@
 package com.befriend.detour.domain.user.dto;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 public class EditNicknameRequestDto {
 
     private String nickname;
-
-    public EditNicknameRequestDto(String nickname) {
-        this.nickname = nickname;
-    }
 
 }

--- a/src/main/java/com/befriend/detour/domain/user/dto/EditPasswordDto.java
+++ b/src/main/java/com/befriend/detour/domain/user/dto/EditPasswordDto.java
@@ -1,0 +1,23 @@
+package com.befriend.detour.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class EditPasswordDto {
+
+    private String password;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값 입니다.")
+    @Size(min = 8, max = 15, message = "비밀번호는 8자 이상, 15자 이하여야 합니다.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[\\W_])\\S{10,}$", message = "password는 알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자로만 구성되어야 합니다.")
+    private String newPassword;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값 입니다.")
+    @Size(min = 8, max = 15, message = "비밀번호는 8자 이상, 15자 이하여야 합니다.")
+    @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[\\W_])\\S{10,}$", message = "password는 알파벳 대소문자(a~z, A~Z), 숫자(0~9), 특수문자로만 구성되어야 합니다.")
+    private String confirmNewPassword;
+
+}

--- a/src/main/java/com/befriend/detour/domain/user/dto/ProfileResponseDto.java
+++ b/src/main/java/com/befriend/detour/domain/user/dto/ProfileResponseDto.java
@@ -1,0 +1,21 @@
+package com.befriend.detour.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ProfileResponseDto {
+
+    private Long id;
+    private String loginId;
+    private Long kakaoId;
+    private String email;
+    private String nickname;
+
+    public ProfileResponseDto(Long id, String loginId, Long kakaoId, String email, String nickname) {
+        this.id = id;
+        this.loginId = loginId;
+        this.kakaoId = kakaoId;
+        this.email = email;
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/befriend/detour/domain/user/dto/ProfileResponseDto.java
+++ b/src/main/java/com/befriend/detour/domain/user/dto/ProfileResponseDto.java
@@ -18,4 +18,5 @@ public class ProfileResponseDto {
         this.email = email;
         this.nickname = nickname;
     }
+
 }

--- a/src/main/java/com/befriend/detour/domain/user/entity/User.java
+++ b/src/main/java/com/befriend/detour/domain/user/entity/User.java
@@ -77,4 +77,12 @@ public class User extends TimeStamped {
         this.nickname = nickname;
     }
 
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
 }

--- a/src/main/java/com/befriend/detour/domain/user/entity/User.java
+++ b/src/main/java/com/befriend/detour/domain/user/entity/User.java
@@ -73,4 +73,8 @@ public class User extends TimeStamped {
         return this;
     }
 
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
 }

--- a/src/main/java/com/befriend/detour/domain/user/service/UserService.java
+++ b/src/main/java/com/befriend/detour/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.befriend.detour.domain.user.service;
 
+import com.befriend.detour.domain.user.dto.EditPasswordDto;
 import com.befriend.detour.domain.user.dto.ProfileResponseDto;
 import com.befriend.detour.domain.user.dto.SignupRequestDto;
 import com.befriend.detour.domain.user.entity.User;
@@ -78,6 +79,32 @@ public class UserService {
         userRepository.save(user);
 
         return getProfile(user);
+    }
+
+    @Transactional
+    public ProfileResponseDto updateEmail(User user, String email) {
+        user.updateEmail(email);
+        userRepository.save(user);
+
+        return getProfile(user);
+    }
+
+    @Transactional
+    public void updatePassword(User user, EditPasswordDto editPasswordDto) {
+        // 현재 비밀번호 체크
+        if(!passwordEncoder.matches(editPasswordDto.getPassword(), user.getPassword())) {
+            throw new CustomException(ErrorCode.INCORRECT_PASSWORD);
+        }
+
+        // 새로운 비밀번호 체크
+        if(!editPasswordDto.getNewPassword().equals(editPasswordDto.getConfirmNewPassword())) {
+            throw new CustomException(ErrorCode.CONFIRM_NEW_PASSWORD_NOT_MATCH);
+        }
+
+        String encodePassword = passwordEncoder.encode(editPasswordDto.getNewPassword());
+
+        user.updatePassword(encodePassword);
+        userRepository.save(user);
     }
 
     public boolean isLoginIdExist(String loginId) {

--- a/src/main/java/com/befriend/detour/domain/user/service/UserService.java
+++ b/src/main/java/com/befriend/detour/domain/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.befriend.detour.domain.user.service;
 
+import com.befriend.detour.domain.user.dto.ProfileResponseDto;
 import com.befriend.detour.domain.user.dto.SignupRequestDto;
 import com.befriend.detour.domain.user.entity.User;
 import com.befriend.detour.domain.user.entity.UserRoleEnum;
@@ -63,6 +64,12 @@ public class UserService {
     public void logout(User user) {
         user.updateRefresh(null);
         userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileResponseDto getProfile(User user) {
+
+        return new ProfileResponseDto(user.getId(), user.getLoginId(), user.getKakaoId(), user.getEmail(), user.getNickname());
     }
 
     public boolean isLoginIdExist(String loginId) {

--- a/src/main/java/com/befriend/detour/domain/user/service/UserService.java
+++ b/src/main/java/com/befriend/detour/domain/user/service/UserService.java
@@ -72,6 +72,14 @@ public class UserService {
         return new ProfileResponseDto(user.getId(), user.getLoginId(), user.getKakaoId(), user.getEmail(), user.getNickname());
     }
 
+    @Transactional
+    public ProfileResponseDto updateNickname(User user, String nickname) {
+        user.updateNickname(nickname);
+        userRepository.save(user);
+
+        return getProfile(user);
+    }
+
     public boolean isLoginIdExist(String loginId) {
         Optional<User> user = userRepository.findByLoginId(loginId);
 

--- a/src/main/java/com/befriend/detour/global/exception/ErrorCode.java
+++ b/src/main/java/com/befriend/detour/global/exception/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode {
     LOGIN_FAIL(404, "로그인에 실패했습니다."),
     WRONG_HTTP_REQUEST(500, "잘못된 http 요청입니다."),
     USER_NOT_ACTIVE(500, "차단된 사용자입니다."),
+    INCORRECT_PASSWORD(500, "현재 비밀번호가 일치하지 않습니다."),
+    CONFIRM_NEW_PASSWORD_NOT_MATCH(500, "새로운 비밀번호가 서로 일치하지 않습니다."),
 
     // schedule 관련 오류 처리
     SCHEDULE_NOT_FOUND(404, "존재하지 않는 일정입니다."),


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#25 
close #25 

## 📝 작업 내용
- 프로필 조회 기능 구현
- 닉네임 수정 기능 구현
- 이메일 수정 기능 구현
- 비밀번호 수정 기능 구현
- 비밀번호 수정시 생기는 오류 로직 구현

### 📸 스크린샷
- **프로필 조회 성공**
![image](https://github.com/user-attachments/assets/301bd6a9-bc4c-430b-b99e-a824e20f09f5)

- **닉네임 수정 성공**
![image](https://github.com/user-attachments/assets/eaa1b79d-df51-48a8-b5fc-43370e95f3a0)

- **이메일 수정 성공**
![image](https://github.com/user-attachments/assets/3355cc59-d429-41dc-a39a-53194d25ff8d)

- **비밀번호 수정 성공**
![image](https://github.com/user-attachments/assets/3db9bb8a-726e-4eb9-8bc4-877e4167d8d4)

- **현재 비밀번호 일치하지 않을때**
![image](https://github.com/user-attachments/assets/5e2e7ddc-fb57-455f-af2d-32820a1eccc8)

- **변경할 새로운 비밀번호 일치하지 않을때**
![image](https://github.com/user-attachments/assets/95620da7-2350-47ed-952b-37338774cefb)

