### PR TITLE
[2024/07/26] feature/auth/email-authentication >> 이메일 인증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.0.4'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/http/10. 이메일 인증.http
+++ b/http/10. 이메일 인증.http
@@ -1,0 +1,13 @@
+### 10-1. 인증 이메일 전송
+POST http://localhost:8081/api/users/send-certification
+Content-Type: application/json
+Authorization: {{access_token}}
+
+{
+  "email" : "chxngbro@gmail.com"
+}
+
+### 10-2. 이메일 인증 확인
+GET http://localhost:8081/api/users/verify?certificationNumber=434586&email=chxngbro@gmail.com
+Content-Type: application/json
+Authorization: {{access_token}}

--- a/src/main/java/com/befriend/detour/domain/user/EmailCertificationService.java
+++ b/src/main/java/com/befriend/detour/domain/user/EmailCertificationService.java
@@ -1,0 +1,69 @@
+package com.befriend.detour.domain.user;
+
+import com.befriend.detour.domain.user.dao.CertificationNumberDao;
+import com.befriend.detour.global.exception.CustomException;
+import com.befriend.detour.global.exception.ErrorCode;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+@RequiredArgsConstructor
+@Service
+public class EmailCertificationService {
+
+    // 이메일 전송을 위한 Spring의 메일 전송 인터페이스
+    private final JavaMailSender mailSender;
+    private final CertificationNumberDao certificationNumberDao;
+
+    public void sendEmailForCertification(String email) throws NoSuchAlgorithmException, MessagingException {
+        // 인증번호 생성
+        String certificationNumber = getCertificationNumber();
+        // 아래 링크를 클릭하여 인증을 완료하도록
+        // TODO: 도메인 구매시 링크 변경 필요
+        String content = String.format("%s/api/users/verify?certificationNumber=%s&email=%s   링크를 3분 이내에 클릭해주세요.", "http://localhost:8081", certificationNumber, email);
+
+        sendMail(email, content);
+        certificationNumberDao.saveCertificationNumber(email, certificationNumber);
+    }
+
+    private static String getCertificationNumber() throws NoSuchAlgorithmException {
+        String result;
+
+        do {
+            int i = SecureRandom.getInstanceStrong().nextInt(999999);
+            result = String.valueOf(i);
+        } while (result.length() != 6);
+
+        return result;
+    }
+
+    private void sendMail(String email, String content) throws MessagingException {
+        MimeMessage mimeMessage = mailSender.createMimeMessage(); // 새로운 MIME 메시지를 생성
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage); // 메시지의 다양한 속성을 설정하는 헬퍼
+
+        helper.setTo(email); // 수신자 이메일 주소 설정
+        helper.setSubject("detour 사이트 인증 요청 메일입니다."); // 제목 설정
+        helper.setText(content); // 이메일 본문 설정
+        mailSender.send(mimeMessage); // 이메일 전송
+    }
+
+    public void verifyEmail(String certificationNumber, String email) {
+        if (isVerify(certificationNumber, email)) {
+            throw new CustomException(ErrorCode.VERIFY_NOT_ALLOWED);
+        }
+        certificationNumberDao.removeCertificationNumber(email); // 유효성 인증 검사 성공시 레디스에서 인증번호 삭제
+    }
+
+    private boolean isVerify(String certificationNumber, String email) {
+        return !(certificationNumberDao.hasKey(email) && // 인증번호가 저장되어 있는지 확인
+                certificationNumberDao.getCertificationNumber(email) // 인증번호 들고옴
+                        .equals(certificationNumber)); // 인증번호와 제공된 인증번호 비교
+    }
+
+}

--- a/src/main/java/com/befriend/detour/domain/user/controller/UserController.java
+++ b/src/main/java/com/befriend/detour/domain/user/controller/UserController.java
@@ -1,11 +1,14 @@
 package com.befriend.detour.domain.user.controller;
 
+import com.befriend.detour.domain.user.service.EmailCertificationService;
 import com.befriend.detour.domain.user.dto.*;
 import com.befriend.detour.domain.user.service.KakaoService;
 import com.befriend.detour.domain.user.service.UserService;
 import com.befriend.detour.global.dto.CommonResponseDto;
 import com.befriend.detour.global.security.UserDetailsImpl;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.netty.handler.codec.MessageAggregationException;
+import jakarta.mail.MessagingException;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +16,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.security.NoSuchAlgorithmException;
 
 @Controller
 @RequiredArgsConstructor
@@ -22,6 +28,7 @@ public class UserController {
 
     private final UserService userService;
     private final KakaoService kakaoService;
+    private final EmailCertificationService emailCertificationService;
 
     @PostMapping("/signup")
     public ResponseEntity<CommonResponseDto> signup(@Valid @RequestBody SignupRequestDto signupRequestDto) {
@@ -84,6 +91,21 @@ public class UserController {
         userService.refreshAccessToken(refreshAccessTokenRequestDto.getNickname(), response);
 
         return ResponseEntity.ok(new CommonResponseDto(200, "액세스 토큰 재발급에 성공하였습니다. 🎉", null));
+    }
+
+    @PostMapping("/send-certification")
+    public ResponseEntity<CommonResponseDto> sendCertificationNumber(@Validated @RequestBody UserCertificateAccountRequestDto request) throws NoSuchAlgorithmException, MessageAggregationException, MessagingException {
+        emailCertificationService.sendEmailForCertification(request.getEmail());
+
+        return ResponseEntity.ok(new CommonResponseDto(200, "인증 이메일 전송에 성공하였습니다. 🎉", null));
+    }
+
+    @GetMapping ("/verify")
+    public ResponseEntity<CommonResponseDto> verifyCertificationNumber(@RequestParam(name = "certificationNumber") String certificationNumber, @RequestParam(name = "email") String email) {
+
+        emailCertificationService.verifyEmail(certificationNumber, email);
+
+        return ResponseEntity.ok(new CommonResponseDto(200, "이메일 인증에 성공하였습니다. 🎉", null));
     }
 
 }

--- a/src/main/java/com/befriend/detour/domain/user/dao/CertificationNumberDao.java
+++ b/src/main/java/com/befriend/detour/domain/user/dao/CertificationNumberDao.java
@@ -22,6 +22,7 @@ public class CertificationNumberDao  {
 
     // 이메일을 키로 사용하여 Redis에서 인증 번호를 조회
     public String getCertificationNumber(String email) {
+
         return stringRedisTemplate.opsForValue().get(email);
     }
 
@@ -32,6 +33,7 @@ public class CertificationNumberDao  {
 
     // 이메일을 키로 사용하여 Redis에 해당 키가 존재하는지 확인
     public boolean hasKey(String email) {
+
         return stringRedisTemplate.hasKey(email);
     }
 

--- a/src/main/java/com/befriend/detour/domain/user/dao/CertificationNumberDao.java
+++ b/src/main/java/com/befriend/detour/domain/user/dao/CertificationNumberDao.java
@@ -1,0 +1,38 @@
+package com.befriend.detour.domain.user.dao;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+// 레디스를 통해 인증 번호를 저장하고 조회하며 삭제하는 작업 수행하는 클래스
+@RequiredArgsConstructor
+@Repository
+public class CertificationNumberDao  {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    // 이메일을 key로 사용하여 인증 번호를 Redis에 저장
+    public void saveCertificationNumber(String email, String certificationNumber) {
+        stringRedisTemplate.opsForValue() // opsForValue는 문자열 값을 처리하는 Redis의 기본 작업을 수행
+                .set(email, certificationNumber,  // key = email, value = 인증 번호
+                        Duration.ofSeconds(180)); // 3분 유효
+    }
+
+    // 이메일을 키로 사용하여 Redis에서 인증 번호를 조회
+    public String getCertificationNumber(String email) {
+        return stringRedisTemplate.opsForValue().get(email);
+    }
+
+    // 이메일을 키로 사용하여 Redis에서 인증 번호 삭제
+    public void removeCertificationNumber(String email) {
+        stringRedisTemplate.delete(email);
+    }
+
+    // 이메일을 키로 사용하여 Redis에 해당 키가 존재하는지 확인
+    public boolean hasKey(String email) {
+        return stringRedisTemplate.hasKey(email);
+    }
+
+}

--- a/src/main/java/com/befriend/detour/domain/user/dto/UserCertificateAccountRequestDto.java
+++ b/src/main/java/com/befriend/detour/domain/user/dto/UserCertificateAccountRequestDto.java
@@ -1,0 +1,14 @@
+package com.befriend.detour.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UserCertificateAccountRequestDto {
+
+    @NotBlank(message = "email은 비워둘 수 없습니다.")
+    @Email(message = "이메일 형식으로 입력해 주세요.")
+    private String email;
+
+}

--- a/src/main/java/com/befriend/detour/domain/user/service/EmailCertificationService.java
+++ b/src/main/java/com/befriend/detour/domain/user/service/EmailCertificationService.java
@@ -61,6 +61,7 @@ public class EmailCertificationService {
     }
 
     private boolean isVerify(String certificationNumber, String email) {
+
         return !(certificationNumberDao.hasKey(email) && // 인증번호가 저장되어 있는지 확인
                 certificationNumberDao.getCertificationNumber(email) // 인증번호 들고옴
                         .equals(certificationNumber)); // 인증번호와 제공된 인증번호 비교

--- a/src/main/java/com/befriend/detour/domain/user/service/EmailCertificationService.java
+++ b/src/main/java/com/befriend/detour/domain/user/service/EmailCertificationService.java
@@ -26,7 +26,7 @@ public class EmailCertificationService {
         String certificationNumber = getCertificationNumber();
         // 아래 링크를 클릭하여 인증을 완료하도록
         // TODO: 도메인 구매시 링크 변경 필요
-        String content = String.format("%s/api/users/verify?certificationNumber=%s&email=%s   링크를 3분 이내에 클릭해주세요.", "http://localhost:8081", certificationNumber, email);
+        String content = String.format("%s/api/users/verify?certificationNumber=%s&email=%s \n 이메일 인증을 위해 링크를 클릭해주세요. \n 3분이 초가될 시 해당 링크로 이메일 인증이 불가능합니다.", "http://localhost:8081", certificationNumber, email);
 
         sendMail(email, content);
         certificationNumberDao.saveCertificationNumber(email, certificationNumber);

--- a/src/main/java/com/befriend/detour/domain/user/service/EmailCertificationService.java
+++ b/src/main/java/com/befriend/detour/domain/user/service/EmailCertificationService.java
@@ -1,4 +1,4 @@
-package com.befriend.detour.domain.user;
+package com.befriend.detour.domain.user.service;
 
 import com.befriend.detour.domain.user.dao.CertificationNumberDao;
 import com.befriend.detour.global.exception.CustomException;

--- a/src/main/java/com/befriend/detour/global/config/RedisConfig.java
+++ b/src/main/java/com/befriend/detour/global/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.befriend.detour.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.auth.host}")
+    private String host;
+    @Value("${spring.data.redis.auth.port}")
+    private int port; // 인증 서버
+
+    @Bean
+    public RedisConnectionFactory redisAuthConnectionFactory() {
+
+        // 레디스와의 서버 연결 설정 (레디스의 서버 주소, 포트)
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    // 빈 이름을 redisTemplate 으로 설정해주지 않으면
+    // A component required a bean named 'redisTemplate' that could not be found. 오류 발생
+    @Bean(name = "redisTemplate")
+    public StringRedisTemplate stringRedisTemplate() {
+        StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+        // stringRedisTemplate 에서 setConnectionFactory 라는 메서드로 서버와 연결 될 수 있도록 구현
+        stringRedisTemplate.setConnectionFactory(redisAuthConnectionFactory());
+
+        return stringRedisTemplate;
+    }
+
+}

--- a/src/main/java/com/befriend/detour/global/config/SecurityConfig.java
+++ b/src/main/java/com/befriend/detour/global/config/SecurityConfig.java
@@ -66,6 +66,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/users/login").permitAll()
                         .requestMatchers("/api/admin/**").hasAuthority("ADMIN")
                         .requestMatchers("/api/users/login/oauth2/code/kakao").permitAll()
+                        .requestMatchers("/api/users/send-certification").permitAll()
+                        .requestMatchers("api/users/verify/**").permitAll()
                         .anyRequest().authenticated()
         );
 

--- a/src/main/java/com/befriend/detour/global/exception/ErrorCode.java
+++ b/src/main/java/com/befriend/detour/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     CONFIRM_NEW_PASSWORD_NOT_MATCH(500, "새로운 비밀번호가 서로 일치하지 않습니다."),
     NO_USERS_FOUND(404, "회원이 없습니다."),
     REFRESH_TOKEN_NOT_VALIDATE(500, "리프레시 토큰이 만료 되었거나 잘못되었습니다."),
+    VERIFY_NOT_ALLOWED(400, "인증 요청이 잘못 되었습니다."),
 
     // schedule 관련 오류 처리
     SCHEDULE_NOT_FOUND(404, "존재하지 않는 일정입니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,8 +27,12 @@ spring:
     connection-timeout: 30000
   data:
     redis:
-      host: localhost
-      port: 6379
+      cache:
+        host: localhost # Redis 캐시 서버의 호스트 (로컬 호스트 사용)
+        port: 6379 # Redis 캐서 서버의 포트
+      auth:
+        host: localhost # Redis 인증 서버의 호스트 (로컬 호스트 사용)
+        port: 6380 # Redis 인증 서버의 포트
 
   security:
     oauth2:
@@ -51,6 +55,15 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-info-authentication-method: header
             user-name-attribute: id
+
+  mail:
+    host: smtp.gmail.com # Gmail의 SMTP 서버 주소
+    port: 587 # Gmail의 SMTP 서버 포트
+    username: detourOfficial0717@gmail.com
+    password: ${APP_PASSWORD}
+    properties:
+      mail.smtp.auth: true # SMTP 인증 사용
+      mail.smtp.starttls.enable: true # TLS 사용
 
 jwt:
   secret:


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #7 
> close #7 

## 📝 작업 내용
- redis 설정
- 인증 메일 보내는 api 구현
- 인증 메일 보내는 로직 구현 (랜덤 수 생성, 수신 이메일 설정 등)
- redis에 인증 번호 저장 기능 구현 (key: email, value: 인증번호)
- 인증 api 구현
- 인증 메일 보내는 로직 구현
- redis에서 인증 완료시 key 삭제

### 📸 스크린샷
- **인증 이메일 전송**
![image](https://github.com/user-attachments/assets/ae5d4033-19d2-434a-8a0f-b4c677576fdb)

- **실제 이메일**
![image](https://github.com/user-attachments/assets/a671ca9a-6f77-4f7e-997d-914eb02e69a1)

- **인증 메일 클릭 시**
![image](https://github.com/user-attachments/assets/01c429d4-fd1a-43ca-8962-88d7092e7b8d)

## 💬 리뷰 요구사항
**제가 생각한 프론트와 백 연결했을때 이메일 인증 로직은 이렇게 되는 건데 혹시 더 좋은 방법이 있는지 궁금합니다!**

1. 사용자가 이메일을 적고 이메일 인증 버튼을 누름 (인증 이메일 전송 api 실행)
2. 사용자의 이메일을 수정할 수 없게 되고 3분 타이머가 돔
3. 사용자가 이메일을 들어가 인증 링크(인증 api)를 클릭하면 인증이 완료 되었다고 체크표시를 해줌 (이메일 변경 못하게 프론트에서 막아야함)
4. 인증이 완료 + 다른 정보를 기입 했을때만 회원가입 버튼이 활성화되게 구현(프론트)