### PR TITLE
[2024/07/26] feature/marker/rd >> Marker 전체 조회, 단건 조회 기능 수정

### DIFF
--- a/http/6. 마커.http
+++ b/http/6. 마커.http
@@ -14,7 +14,7 @@ Content-Type: application/json
 Authorization: {{access_token}}
 
 ### 6-3. 마커 단건 조회
-GET http://localhost:8081/api/daily-plans/2/markers/3
+GET http://localhost:8081/api/daily-plans/1/markers/1
 Content-Type: application/json
 Authorization: {{access_token}}
 

--- a/src/main/java/com/befriend/detour/domain/marker/repository/MarkerRepositoryCustom.java
+++ b/src/main/java/com/befriend/detour/domain/marker/repository/MarkerRepositoryCustom.java
@@ -12,4 +12,6 @@ public interface MarkerRepositoryCustom {
 
     Optional<Marker> findByIdAndDailyPlanId(Long markerId, Long dailyPlanId);
 
+    Optional<MarkerResponseDto> findResponseByIdAndDailyPlanId(Long markerId, Long dailyPlanId);
+
 }

--- a/src/main/java/com/befriend/detour/domain/marker/repository/MarkerRepositoryCustom.java
+++ b/src/main/java/com/befriend/detour/domain/marker/repository/MarkerRepositoryCustom.java
@@ -12,6 +12,6 @@ public interface MarkerRepositoryCustom {
 
     Optional<Marker> findByIdAndDailyPlanId(Long markerId, Long dailyPlanId);
 
-    Optional<MarkerResponseDto> findResponseByIdAndDailyPlanId(Long markerId, Long dailyPlanId);
+    Optional<MarkerResponseDto> fetchMarkerDetails(Long markerId, Long dailyPlanId);
 
 }

--- a/src/main/java/com/befriend/detour/domain/marker/repository/MarkerRepositoryImpl.java
+++ b/src/main/java/com/befriend/detour/domain/marker/repository/MarkerRepositoryImpl.java
@@ -9,7 +9,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -23,31 +22,28 @@ public class MarkerRepositoryImpl implements MarkerRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
     private final FileRepository fileRepository;
 
-
     @Override
     public List<MarkerResponseDto> findByDailyPlanId(Long dailyPlanId) {
 
-        List<Marker> markers = jpaQueryFactory.selectFrom(marker)
+        return jpaQueryFactory.selectFrom(marker)
                 .where(marker.dailyPlan.id.eq(dailyPlanId),
                         marker.status.ne(MarkerStatusEnum.DELETED))
                 .orderBy(marker.id.asc())
-                .fetch();
+                .fetch()
+                .stream()
+                .map(this::toMarkerResponseDto)
+                .collect(Collectors.toList());
+    }
 
-        List<MarkerResponseDto> markerResponseDto = new ArrayList<>();
-        for (Marker marker : markers) {
-            List<String> imageUrl = fileRepository.findByMarkerId(marker.getId())
-                    .stream()
-                    .map(File::getFileUrl)
-                    .collect(Collectors.toList());
-            markerResponseDto.add(new MarkerResponseDto(marker, imageUrl));
-        }
+    @Override
+    public Optional<MarkerResponseDto> findResponseByIdAndDailyPlanId(Long markerId, Long dailyPlanId) {
 
-        return markerResponseDto;
+        return findByIdAndDailyPlanId(markerId, dailyPlanId)
+                .map(this::toMarkerResponseDto);
     }
 
     @Override
     public Optional<Marker> findByIdAndDailyPlanId(Long markerId, Long dailyPlanId) {
-
         Marker result = jpaQueryFactory.selectFrom(marker)
                 .where(marker.id.eq(markerId)
                         .and(marker.dailyPlan.id.eq(dailyPlanId)))
@@ -56,4 +52,13 @@ public class MarkerRepositoryImpl implements MarkerRepositoryCustom {
         return Optional.ofNullable(result);
     }
 
+    // 마커에 연관된 파일 목록을 조회하여 URL을 추출한 뒤 리스트로 변환하여 MarkerResponseDto 객체를 생성하여 반환
+    private MarkerResponseDto toMarkerResponseDto(Marker marker) {
+        List<String> imageUrls = fileRepository.findByMarkerId(marker.getId())
+                .stream()
+                .map(File::getFileUrl)
+                .collect(Collectors.toList());
+
+        return new MarkerResponseDto(marker, imageUrls);
+    }
 }

--- a/src/main/java/com/befriend/detour/domain/marker/repository/MarkerRepositoryImpl.java
+++ b/src/main/java/com/befriend/detour/domain/marker/repository/MarkerRepositoryImpl.java
@@ -36,7 +36,7 @@ public class MarkerRepositoryImpl implements MarkerRepositoryCustom {
     }
 
     @Override
-    public Optional<MarkerResponseDto> findResponseByIdAndDailyPlanId(Long markerId, Long dailyPlanId) {
+    public Optional<MarkerResponseDto> fetchMarkerDetails(Long markerId, Long dailyPlanId) {
 
         return findByIdAndDailyPlanId(markerId, dailyPlanId)
                 .map(this::toMarkerResponseDto);

--- a/src/main/java/com/befriend/detour/domain/marker/service/MarkerService.java
+++ b/src/main/java/com/befriend/detour/domain/marker/service/MarkerService.java
@@ -2,7 +2,6 @@ package com.befriend.detour.domain.marker.service;
 
 import com.befriend.detour.domain.dailyplan.entity.DailyPlan;
 import com.befriend.detour.domain.dailyplan.service.DailyPlanService;
-import com.befriend.detour.domain.file.entity.File;
 import com.befriend.detour.domain.file.repository.FileRepository;
 import com.befriend.detour.domain.marker.dto.MarkerContentRequestDto;
 import com.befriend.detour.domain.marker.dto.MarkerLocationResponseDto;
@@ -20,9 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -65,19 +62,9 @@ public class MarkerService {
             throw new CustomException(ErrorCode.MARKER_NOT_FOUND_IN_DAILY_PLAN);
         }
 
-        Marker marker = markerRepository.findByIdAndDailyPlanId(markerId, dailyPlanId).orElseThrow(
+        return markerRepository.findResponseByIdAndDailyPlanId(markerId, dailyPlanId).orElseThrow(
                 () -> new CustomException(ErrorCode.MARKER_NOT_FOUND)
         );
-
-        findMarker(markerId);
-
-        // 파일 URL 목록 가져오기
-        List<File> files = fileRepository.findByMarkerId(markerId);
-        List<String> imageUrls = files.stream()
-                .map(File::getFileUrl)
-                .collect(Collectors.toList());
-
-        return new MarkerResponseDto(marker, imageUrls);
     }
 
     // 위도 경도 조회

--- a/src/main/java/com/befriend/detour/domain/marker/service/MarkerService.java
+++ b/src/main/java/com/befriend/detour/domain/marker/service/MarkerService.java
@@ -62,7 +62,7 @@ public class MarkerService {
             throw new CustomException(ErrorCode.MARKER_NOT_FOUND_IN_DAILY_PLAN);
         }
 
-        return markerRepository.findResponseByIdAndDailyPlanId(markerId, dailyPlanId).orElseThrow(
+        return markerRepository.fetchMarkerDetails(markerId, dailyPlanId).orElseThrow(
                 () -> new CustomException(ErrorCode.MARKER_NOT_FOUND)
         );
     }

--- a/src/main/java/com/befriend/detour/domain/marker/service/MarkerService.java
+++ b/src/main/java/com/befriend/detour/domain/marker/service/MarkerService.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #20 

## 📝 작업 내용

- 마커 전체 조회 : 이미지 url이 포함되게 수정
- 마커 단건 조회 : MarkerResponseDto 객체를 생성할 때 파일 URL 목록을 포함시키는 로직을 MarkerRepositoryImpl로 이동

### 📸 스크린샷 
![image](https://github.com/user-attachments/assets/05fd2ee1-e44d-4ca3-ad7e-bd0533af0d1a)

## 💬 리뷰 요구사항

> 마커 리팩토링 관련 이슈는 아직 닫지 않을게요!
